### PR TITLE
Elasticsearch 8.4 and URL initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ If you'd like to add extra functionality, either [open an issue](https://github.
 
 ## Elasticsearch Version
 
-The library has been tested again Elasticsearch 7.6.2, but should work for the most part against older versions.
+The library has been tested again Elasticsearch 8.4, but should work for the most part against older versions.

--- a/Sources/ElasticsearchNIOClient/ElasticsearchClient+ValidationError.swift
+++ b/Sources/ElasticsearchNIOClient/ElasticsearchClient+ValidationError.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension ElasticsearchClient {
+    public struct ValidationError: LocalizedError, Equatable {
+        public static let invalidURLString = ValidationError(.invalidURLString)
+        public static let missingURLScheme = ValidationError(.missingURLScheme)
+        public static let invalidURLScheme = ValidationError(.invalidURLScheme)
+        public static let missingURLHost = ValidationError(.missingURLHost)
+
+        var localizedDescription: String { self.kind.localizedDescription }
+
+        private let kind: Kind
+        
+        private init(_ kind: Kind) { self.kind = kind }
+        
+        public static func ==(lhs: ValidationError, rhs: ValidationError) -> Bool {
+            return lhs.kind == rhs.kind
+        }
+        
+        private enum Kind: LocalizedError {
+            case invalidURLString
+            case missingURLScheme
+            case invalidURLScheme
+            case missingURLHost
+            
+            var localizedDescription: String {
+                let message: String = {
+                    switch self {
+                    case .invalidURLString: return "invalid URL string"
+                    case .missingURLScheme: return "URL scheme is missing"
+                    case .invalidURLScheme: return "invalid URL scheme, expected 'http' or 'https'"
+                    case .missingURLHost: return "missing remote hostname"
+                    }
+                }()
+                return "Elasticsearch connection configuration validation failed: \(message)"
+            }
+        }
+    }
+}

--- a/Sources/ElasticsearchNIOClient/Models/ESBulkResponse.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESBulkResponse.swift
@@ -15,7 +15,6 @@ public struct ESBulkResponseItem: Codable {
 
 public struct ESBulkResponseItemAction: Codable {
     public let index: String
-    public let type: String
     public let id: String
     public let version: Int?
     public let result: String?
@@ -25,7 +24,6 @@ public struct ESBulkResponseItemAction: Codable {
 
     enum CodingKeys: String, CodingKey {
         case index = "_index"
-        case type = "_type"
         case id = "_id"
         case version = "_version"
         case result

--- a/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
+++ b/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
@@ -18,7 +18,9 @@ class ElasticSearchIntegrationTests: XCTestCase {
         let logger = Logger(label: "io.brokenhands.swift-soto-elasticsearch.test")
         httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
         client = ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, scheme: "http", host: "localhost", port: 9200)
-        _ = try client.deleteIndex("_all").wait()
+        if try client.checkIndexExists(indexName).wait() {
+            _ = try client.deleteIndex(indexName).wait()
+        }
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
+++ b/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
@@ -17,7 +17,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let logger = Logger(label: "io.brokenhands.swift-soto-elasticsearch.test")
         httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
-        client = ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, scheme: "http", host: "localhost", port: 9200)
+        client = try! ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, scheme: "http", host: "localhost", port: 9200)
         if try client.checkIndexExists(indexName).wait() {
             _ = try client.deleteIndex(indexName).wait()
         }
@@ -29,6 +29,41 @@ class ElasticSearchIntegrationTests: XCTestCase {
     }
 
     // MARK: - Tests
+    func testURLSetup() throws {
+        let logger = Logger(label: "io.brokenhands.swift-soto-elasticsearch.test")
+        
+        let invalidURLString = ""
+        XCTAssertThrowsError(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, url: invalidURLString)) { error in
+            XCTAssertEqual(error as! ElasticsearchClient.ValidationError, .invalidURLString)
+        }
+    
+        let urlWithoutScheme = URL(string: "://localhost:9200")!
+        XCTAssertThrowsError(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, url: urlWithoutScheme)) { error in
+            XCTAssertEqual(error as! ElasticsearchClient.ValidationError, .missingURLScheme)
+        }
+        
+        let urlWithIncorrectScheme = URL(string: "localhost:9200")!
+        XCTAssertThrowsError(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, url: urlWithIncorrectScheme)) { error in
+            XCTAssertEqual(error as! ElasticsearchClient.ValidationError, .invalidURLScheme)
+        }
+        
+        let urlWithoutHost = URL(string: "http://:9200")!
+        XCTAssertThrowsError(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, url: urlWithoutHost)) { error in
+            XCTAssertEqual(error as! ElasticsearchClient.ValidationError, .missingURLHost)
+        }
+        
+        let correctURL = URL(string: "http://localhost:9200")!
+        XCTAssertNoThrow(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, url: correctURL))
+        
+        XCTAssertThrowsError(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, scheme: "incorrectScheme", host: "localhost", port: 9200)) { error in
+            XCTAssertEqual(error as! ElasticsearchClient.ValidationError, .invalidURLScheme)
+        }
+        
+        XCTAssertNoThrow(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, scheme: "http", host: "localhost", port: 9200))
+        
+        XCTAssertNoThrow(try ElasticsearchClient(httpClient: httpClient, eventLoop: eventLoopGroup.next(), logger: logger, scheme: "https", host: "localhost", port: 9200))
+    }
+    
     func testSearchingItems() throws {
         try setupItems()
 


### PR DESCRIPTION
Enables compatibility with elasticsearch 8 by removing the `_type` field from bulk requests.
Furter adds an initializer which allows constructing from URLs and URL Strings (#11).