### PR TITLE
Use hashable id  instead of string and allow hashable document to be updated with its own id.

### DIFF
--- a/Sources/ElasticsearchNIOClient/ElasticsearchClient+Requests.swift
+++ b/Sources/ElasticsearchNIOClient/ElasticsearchClient+Requests.swift
@@ -121,6 +121,18 @@ extension ElasticsearchClient {
         }
     }
 
+    public func updateDocument<Document: Encodable & Identifiable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse> {
+        do {
+            let url = try buildURL(path: "/\(indexName)/_doc/\(document.id)")
+            let body = try ByteBuffer(data: self.jsonEncoder.encode(document))
+            var headers = HTTPHeaders()
+            headers.add(name: "content-type", value: "application/json")
+            return sendRequest(url: url, method: .PUT, headers: headers, body: body)
+        } catch {
+            return self.eventLoop.makeFailedFuture(error)
+        }
+    }
+
     public func updateDocumentWithScript<Script: Encodable>(_ script: Script, id: String, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse> {
         do {
             let url = try buildURL(path: "/\(indexName)/_update/\(id)")

--- a/Sources/ElasticsearchNIOClient/ElasticsearchClient+Requests.swift
+++ b/Sources/ElasticsearchNIOClient/ElasticsearchClient+Requests.swift
@@ -4,7 +4,7 @@ import NIOHTTP1
 import NIOFoundationCompat
 
 extension ElasticsearchClient {
-    public func get<Document: Decodable>(id: String, from indexName: String) -> EventLoopFuture<ESGetSingleDocumentResponse<Document>> {
+    public func get<Document: Decodable, ID: Hashable>(id: ID, from indexName: String) -> EventLoopFuture<ESGetSingleDocumentResponse<Document>> {
         do {
             let url = try buildURL(path: "/\(indexName)/_doc/\(id)")
             return sendRequest(url: url, method: .GET, headers: .init(), body: nil)
@@ -13,7 +13,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func bulk<Document: Encodable>(_ operations: [ESBulkOperation<Document>]) -> EventLoopFuture<ESBulkResponse> {
+    public func bulk<Document: Encodable, ID: Hashable>(_ operations: [ESBulkOperation<Document, ID>]) -> EventLoopFuture<ESBulkResponse> {
         guard operations.count > 0 else {
             return self.eventLoop.makeFailedFuture(ElasticSearchClientError(message: "No operations to perform for the bulk API", status: nil))
         }
@@ -85,7 +85,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func createDocument<Document: Encodable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESCreateDocumentResponse> {
+    public func createDocument<Document: Encodable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESCreateDocumentResponse<String>> {
         do {
             let url = try buildURL(path: "/\(indexName)/_doc")
             let body = try ByteBuffer(data: self.jsonEncoder.encode(document))
@@ -97,7 +97,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func createDocumentWithID<Document: Encodable & Identifiable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESCreateDocumentResponse> {
+    public func createDocumentWithID<Document: Encodable & Identifiable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESCreateDocumentResponse<Document.ID>> {
         do {
             let url = try buildURL(path: "/\(indexName)/_doc/\(document.id)")
             let body = try ByteBuffer(data: self.jsonEncoder.encode(document))
@@ -109,7 +109,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func updateDocument<Document: Encodable>(_ document: Document, id: String, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse> {
+    public func updateDocument<Document: Encodable, ID: Hashable>(_ document: Document, id: ID, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse<ID>> {
         do {
             let url = try buildURL(path: "/\(indexName)/_doc/\(id)")
             let body = try ByteBuffer(data: self.jsonEncoder.encode(document))
@@ -121,7 +121,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func updateDocument<Document: Encodable & Identifiable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse> {
+    public func updateDocument<Document: Encodable & Identifiable>(_ document: Document, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse<Document.ID>> {
         do {
             let url = try buildURL(path: "/\(indexName)/_doc/\(document.id)")
             let body = try ByteBuffer(data: self.jsonEncoder.encode(document))
@@ -133,7 +133,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func updateDocumentWithScript<Script: Encodable>(_ script: Script, id: String, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse> {
+    public func updateDocumentWithScript<Script: Encodable, ID: Hashable>(_ script: Script, id: ID, in indexName: String) -> EventLoopFuture<ESUpdateDocumentResponse<ID>> {
         do {
             let url = try buildURL(path: "/\(indexName)/_update/\(id)")
             let body = try ByteBuffer(data: self.jsonEncoder.encode(script))
@@ -145,7 +145,7 @@ extension ElasticsearchClient {
         }
     }
 
-    public func deleteDocument(id: String, from indexName: String) -> EventLoopFuture<ESDeleteDocumentResponse> {
+    public func deleteDocument<ID: Hashable>(id: ID, from indexName: String) -> EventLoopFuture<ESDeleteDocumentResponse> {
         do {
             let url = try buildURL(path: "/\(indexName)/_doc/\(id)")
             return sendRequest(url: url, method: .DELETE, headers: .init(), body: nil)

--- a/Sources/ElasticsearchNIOClient/Models/ESBulkOperation.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESBulkOperation.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public struct ESBulkOperation<Document> where Document: Encodable {
+public struct ESBulkOperation<Document, ID> where Document: Encodable, ID: Hashable & Encodable {
     public let operationType: BulkOperationType
     public let document: Document?
-    public let id: String
+    public let id: ID
     public let index: String
 
-    public init(operationType: BulkOperationType, index: String, id: String, document: Document?) {
+    public init(operationType: BulkOperationType, index: String, id: ID, document: Document?) {
         self.operationType = operationType
         self.index = index
         self.id = id

--- a/Sources/ElasticsearchNIOClient/Models/ESCreateDocumentResponse.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESCreateDocumentResponse.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct ESCreateDocumentResponse: Codable {
-    public let id: String
+public struct ESCreateDocumentResponse<ID>: Codable where ID: Hashable & Codable {
+    public let id: ID
     public let index: String
     public let version: Int?
     public let result: String

--- a/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
+++ b/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
@@ -96,7 +96,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
     func testCreateDocumentWithID() throws {
         let item = SomeItem(id: UUID(), name: "Banana")
         let response = try client.createDocumentWithID(item, in: self.indexName).wait()
-        XCTAssertEqual(item.id.uuidString, response.id)
+        XCTAssertEqual(item.id, response.id)
         XCTAssertEqual(response.index, self.indexName)
         XCTAssertEqual(response.result, "created")
     }
@@ -106,7 +106,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         _ = try client.createDocumentWithID(item, in: self.indexName).wait()
         Thread.sleep(forTimeInterval: 0.5)
         let updatedItem = SomeItem(id: item.id, name: "Bananas")
-        let response = try client.updateDocument(updatedItem, id: item.id.uuidString, in: self.indexName).wait()
+        let response = try client.updateDocument(updatedItem, id: item.id, in: self.indexName).wait()
         XCTAssertEqual(response.result, "updated")
     }
 
@@ -129,7 +129,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         XCTAssertEqual(results.count, 1)
         Thread.sleep(forTimeInterval: 0.5)
 
-        let response = try client.deleteDocument(id: item.id.uuidString, from: self.indexName).wait()
+        let response = try client.deleteDocument(id: item.id, from: self.indexName).wait()
         XCTAssertEqual(response.result, "deleted")
         Thread.sleep(forTimeInterval: 0.5)
 
@@ -179,7 +179,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
             items.append(item)
         }
 
-        let itemsWithIndex = items.map { ESBulkOperation(operationType: .create, index: self.indexName, id: $0.id.uuidString, document: $0) }
+        let itemsWithIndex = items.map { ESBulkOperation(operationType: .create, index: self.indexName, id: $0.id, document: $0) }
         let response = try client.bulk(itemsWithIndex).wait()
         XCTAssertEqual(response.errors, false)
         XCTAssertEqual(response.items.count, 10)
@@ -196,10 +196,10 @@ class ElasticSearchIntegrationTests: XCTestCase {
         let item3 = SomeItem(id: UUID(), name: "Item 3")
         let item4 = SomeItem(id: UUID(), name: "Item 4")
         let bulkOperation = [
-            ESBulkOperation(operationType: .create, index: self.indexName, id: item1.id.uuidString, document: item1),
-            ESBulkOperation(operationType: .index, index: self.indexName, id: item2.id.uuidString, document: item2),
-            ESBulkOperation(operationType: .update, index: self.indexName, id: item3.id.uuidString, document: item3),
-            ESBulkOperation(operationType: .delete, index: self.indexName, id: item4.id.uuidString, document: item4),
+            ESBulkOperation(operationType: .create, index: self.indexName, id: item1.id, document: item1),
+            ESBulkOperation(operationType: .index, index: self.indexName, id: item2.id, document: item2),
+            ESBulkOperation(operationType: .update, index: self.indexName, id: item3.id, document: item3),
+            ESBulkOperation(operationType: .delete, index: self.indexName, id: item4.id, document: item4),
         ]
 
         let response = try client.bulk(bulkOperation).wait()
@@ -248,7 +248,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
 
         Thread.sleep(forTimeInterval: 1.0)
 
-        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: item.id.uuidString, from: self.indexName).wait()
+        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: item.id, from: self.indexName).wait()
         XCTAssertEqual(retrievedItem.source.name, item.name)
     }
 
@@ -276,7 +276,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         let scriptBody = ScriptBody(inline: "ctx._source.count = ctx._source.count += 1")
 
         let bulkOperation = [
-            ESBulkOperation(operationType: .updateScript, index: self.indexName, id: items[0].id.uuidString, document: scriptBody),
+            ESBulkOperation(operationType: .updateScript, index: self.indexName, id: items[0].id, document: scriptBody),
         ]
 
         let response = try client.bulk(bulkOperation).wait()
@@ -284,7 +284,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         XCTAssertNotNil(response.items.first?.update)
         XCTAssertFalse(response.errors)
 
-        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: items[0].id.uuidString, from: self.indexName).wait()
+        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: items[0].id, from: self.indexName).wait()
         XCTAssertEqual(retrievedItem.source.count, 1)
     }
 
@@ -306,10 +306,10 @@ class ElasticSearchIntegrationTests: XCTestCase {
         let scriptBody = ScriptBody(inline: "ctx._source.count = ctx._source.count += 1")
         let request = ScriptRequest(script: scriptBody)
 
-        let response = try client.updateDocumentWithScript(request, id: item.id.uuidString, in: self.indexName).wait()
+        let response = try client.updateDocumentWithScript(request, id: item.id, in: self.indexName).wait()
         XCTAssertEqual(response.result, "updated")
 
-        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: item.id.uuidString, from: self.indexName).wait()
+        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: item.id, from: self.indexName).wait()
         XCTAssertEqual(retrievedItem.source.count, 1)
     }
 
@@ -331,10 +331,10 @@ class ElasticSearchIntegrationTests: XCTestCase {
         let scriptBody = ScriptBody(inline: "if(ctx._source.containsKey('count')) { ctx._source.count += 1 } else { ctx._source.count = 1 }")
         let request = ScriptRequest(script: scriptBody)
 
-        let response = try client.updateDocumentWithScript(request, id: item.id.uuidString, in: self.indexName).wait()
+        let response = try client.updateDocumentWithScript(request, id: item.id, in: self.indexName).wait()
         XCTAssertEqual(response.result, "updated")
 
-        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: item.id.uuidString, from: self.indexName).wait()
+        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: item.id, from: self.indexName).wait()
         XCTAssertEqual(retrievedItem.source.count, 1)
     }
 
@@ -362,7 +362,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         let scriptBody = ScriptBody(inline: "if(ctx._source.containsKey('count')) { ctx._source.count += 1 } else { ctx._source.count = 1 }")
 
         let bulkOperation = [
-            ESBulkOperation(operationType: .updateScript, index: self.indexName, id: items[0].id.uuidString, document: scriptBody),
+            ESBulkOperation(operationType: .updateScript, index: self.indexName, id: items[0].id, document: scriptBody),
         ]
 
         let response = try client.bulk(bulkOperation).wait()
@@ -370,7 +370,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
         XCTAssertNotNil(response.items.first?.update)
         XCTAssertFalse(response.errors)
 
-        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: items[0].id.uuidString, from: self.indexName).wait()
+        let retrievedItem: ESGetSingleDocumentResponse<SomeItem> = try client.get(id: items[0].id, from: self.indexName).wait()
         XCTAssertEqual(retrievedItem.source.count, 1)
     }
 

--- a/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
+++ b/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
@@ -101,12 +101,21 @@ class ElasticSearchIntegrationTests: XCTestCase {
         XCTAssertEqual(response.result, "created")
     }
 
-    func testUpdatingDocument() throws {
+    func testUpdateDocumentWithCustomId() throws {
         let item = SomeItem(id: UUID(), name: "Banana")
         _ = try client.createDocumentWithID(item, in: self.indexName).wait()
         Thread.sleep(forTimeInterval: 0.5)
         let updatedItem = SomeItem(id: item.id, name: "Bananas")
         let response = try client.updateDocument(updatedItem, id: item.id.uuidString, in: self.indexName).wait()
+        XCTAssertEqual(response.result, "updated")
+    }
+
+    func testUpdateDocumentWithID() throws {
+        let item = SomeItem(id: UUID(), name: "Banana")
+        _ = try client.createDocumentWithID(item, in: self.indexName).wait()
+        Thread.sleep(forTimeInterval: 0.5)
+        let updatedItem = SomeItem(id: item.id, name: "Bananas")
+        let response = try client.updateDocument(updatedItem, in: self.indexName).wait()
         XCTAssertEqual(response.result, "updated")
     }
 


### PR DESCRIPTION
Allows `Identifiable` documents to be updated without separately passing their id to to update function by adding a new function:
```swift
public func updateDocument<Document: Encodable & Identifiable>(_ document: Document, in indexName: String)
```
Furthermore improves all methods which require an id by making the id a generic `Hashable` instead of a `String`. This allows e.g. `UUID`s and `Int`s to be passed as an id.