### PR TITLE
Retrieve total count from multiple documents response

### DIFF
--- a/Sources/ElasticsearchNIOClient/Models/ESMultipleDocumentResponse.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESMultipleDocumentResponse.swift
@@ -4,7 +4,11 @@ public struct ESGetMultipleDocumentsResponse<Document: Decodable>: Decodable {
     public struct Hits: Decodable {
         public struct Total: Decodable {
             public let value: Int
-            public let relation: String
+            public let relation: Relation
+
+            public enum Relation: String, Decodable {
+                case eq, gte
+            }
         }
 
         public let total: Total

--- a/Sources/ElasticsearchNIOClient/Models/ESMultipleDocumentResponse.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESMultipleDocumentResponse.swift
@@ -2,6 +2,12 @@ import Foundation
 
 public struct ESGetMultipleDocumentsResponse<Document: Decodable>: Decodable {
     public struct Hits: Decodable {
+        public struct Total: Decodable {
+            public let value: Int
+            public let relation: String
+        }
+
+        public let total: Total
         public let hits: [ESGetSingleDocumentResponse<Document>]
     }
 

--- a/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
+++ b/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
@@ -85,6 +85,21 @@ class ElasticSearchIntegrationTests: XCTestCase {
         XCTAssertEqual(results.count, 5)
     }
 
+    func testSearchDocumentsTotal() throws {
+        for index in 1...100 {
+            let name = "Some \(index) Apples"
+            let item = SomeItem(id: UUID(), name: name)
+            _ = try client.createDocument(item, in: self.indexName).wait()
+        }
+
+        // This is required for ES to settle and load the indexes to return the right results
+        Thread.sleep(forTimeInterval: 1.0)
+
+        let results = try client.searchDocuments(from: indexName, searchTerm: "Apples", type: SomeItem.self).wait()
+        XCTAssertEqual(results.hits.total.value, 100)
+        XCTAssertEqual(results.hits.total.relation, "eq")
+    }
+
     func testCreateDocument() throws {
         let item = SomeItem(id: UUID(), name: "Banana")
         let response = try client.createDocument(item, in: self.indexName).wait()

--- a/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
+++ b/Tests/ElasticsearchNIOClientTests/ElasticsearchNIOClientTests.swift
@@ -97,7 +97,7 @@ class ElasticSearchIntegrationTests: XCTestCase {
 
         let results = try client.searchDocuments(from: indexName, searchTerm: "Apples", type: SomeItem.self).wait()
         XCTAssertEqual(results.hits.total.value, 100)
-        XCTAssertEqual(results.hits.total.relation, "eq")
+        XCTAssertEqual(results.hits.total.relation, .eq)
     }
 
     func testCreateDocument() throws {


### PR DESCRIPTION
Retrieve the total document count from a multiple documents response.