### PR TITLE
Add sort to Single Document Response 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+
+        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.7")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -29,6 +31,8 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+
+                .product(name: "AnyCodable", package: "AnyCodable")
             ]),
         .testTarget(
             name: "ElasticsearchNIOClientTests",

--- a/Sources/ElasticsearchNIOClient/Models/ESSingleDocumentResponse.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESSingleDocumentResponse.swift
@@ -1,15 +1,18 @@
 import Foundation
+import AnyCodable
 
 public struct ESGetSingleDocumentResponse<Document: Decodable>: Decodable {
     public let id: String
     public let index: String
     public let version: Int?
     public let source: Document
+    public let sort: AnyCodable?
     
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case index = "_index"
         case version = "_version"
         case source = "_source"
+        case sort 
     }
 }


### PR DESCRIPTION
we need to have the sort field so we can use for pagination with the `search_after` property 