### PR TITLE
Make total hits optional

### DIFF
--- a/Sources/ElasticsearchNIOClient/Models/ESMultipleDocumentResponse.swift
+++ b/Sources/ElasticsearchNIOClient/Models/ESMultipleDocumentResponse.swift
@@ -11,7 +11,7 @@ public struct ESGetMultipleDocumentsResponse<Document: Decodable>: Decodable {
             }
         }
 
-        public let total: Total
+        public let total: Total?
         public let hits: [ESGetSingleDocumentResponse<Document>]
     }
 


### PR DESCRIPTION
if `track_total_hits` is sent in the request as `false`, the property `total` in `hits` is nil 

see https://www.elastic.co/guide/en/elasticsearch/reference/8.11/search-your-data.html 