### PR TITLE
Remove --enable-test-discovery argument

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test
-      run: swift test --enable-test-discovery --sanitize=thread
+      run: swift test --sanitize=thread
 
   test-v8_4:
     name: Run Tests for Elasticsearch 8.4
@@ -37,4 +37,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test
-      run: swift test --enable-test-discovery --sanitize=thread
+      run: swift test --sanitize=thread


### PR DESCRIPTION
Since the argument `--enable-test-discovery` is not needed, it can be removed.

Warning here https://github.com/brokenhandsio/elasticsearch-nio-client/actions/runs/6805359099/job/18516691175#step:4:76 