### PR TITLE
queryItems arg for custom func in ElasticsearchClient

### DIFF
--- a/Sources/ElasticsearchNIOClient/ElasticsearchClient+Requests.swift
+++ b/Sources/ElasticsearchNIOClient/ElasticsearchClient+Requests.swift
@@ -276,9 +276,9 @@ extension ElasticsearchClient {
         }
     }
 
-    public func custom(_ path: String, method: HTTPMethod, body: Data) -> EventLoopFuture<Data> {
+    public func custom(_ path: String, queryItems: [URLQueryItem] = [], method: HTTPMethod, body: Data) -> EventLoopFuture<Data> {
         do {
-            let url = try buildURL(path: path)
+            let url = try buildURL(path: path, queryItems: queryItems)
             let body = ByteBuffer(data: body)
             var headers = HTTPHeaders()
             headers.add(name: "content-type", value: "application/json")


### PR DESCRIPTION
Option to submit queryItems to custom func, which will be handed over to the buildURL func